### PR TITLE
Add 2.2.4 to changelog on main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ All notable changes to this project will be documented in this file. For info on
 - Fix multipart filename generation for filenames that contain spaces. Encode spaces as "%20" instead of "+" which will be decoded properly by the multipart parser. ([#1736](https://github.com/rack/rack/pull/1645), [@muirdm](https://github.com/muirdm))
 - `Rack::Request#scheme` returns `ws` or `wss` when one of the `X-Forwarded-Scheme` / `X-Forwarded-Proto` headers is set to `ws` or `wss`, respectively. ([#1730](https://github.com/rack/rack/issues/1730), [@erwanst](https://github.com/erwanst))
 
+## [2.2.4] - 2022-06-30
+
+- Better support for lower case headers in `Rack::ETag` middleware. ([#1919](https://github.com/rack/rack/pull/1919), [@ioquatix](https://github.com/ioquatix))
+- Use custom exception on params too deep error. ([#1838](https://github.com/rack/rack/pull/1838), [@simi](https://github.com/simi))
+
 ## [2.2.3.1] - 2022-05-27
 
 - [CVE-2022-30123] Fix shell escaping issue in Common Logger


### PR DESCRIPTION
https://github.com/rack/rack/blob/2.2.4/CHANGELOG.md includes an entry from 2.2.4 which is not currently visible on main branch. Copy the changelog contents over from the `CHANGELOG.md` on `2.2.4` tag and submit it as a PR against main branch.